### PR TITLE
Update ChatGPT and Twitter stuff

### DIFF
--- a/clippy.json
+++ b/clippy.json
@@ -15,7 +15,7 @@
         "Why do programmers prefer dark mode? Because light attracts bugs!",
         "Why was the JavaScript developer sad? Because he didn't get callbacks!"
     ],
-    "twitter": [
+    "x.com": [
         "Tweets can only be 280 characters long!",
         "Get me out of here. PLEASE."
     ],
@@ -364,7 +364,7 @@
         "JOKE: A client asks his adviser, \"is all my money really gone?\"\"No, of course not,\" the adviser says.\"It's just with somebody else!\". HAHAHA",
         "JOKE: After I spoke to my financial adviser I slept like a baby. I woke up every hour and cried. HAHAHA"
     ],
-    "chat.openai.com": [
+    "chatgpt.com": [
         "Oh, great, another human relying on AI to do their thinking for them.",
         "Well, aren't you just the epitome of efficiency, using AI to do your bidding."
     ],

--- a/clippy.json
+++ b/clippy.json
@@ -16,7 +16,7 @@
         "Why was the JavaScript developer sad? Because he didn't get callbacks!"
     ],
     "x.com": [
-        "Posts can only be 280 characters long!",
+        "Tweets can only be 280 characters long!",
         "Get me out of here. PLEASE."
     ],
     "github.com/capJavert/clippy": "Hey look, it's my code!",

--- a/clippy.json
+++ b/clippy.json
@@ -16,7 +16,7 @@
         "Why was the JavaScript developer sad? Because he didn't get callbacks!"
     ],
     "x.com": [
-        "Tweets can only be 280 characters long!",
+        "Posts can only be 280 characters long!",
         "Get me out of here. PLEASE."
     ],
     "github.com/capJavert/clippy": "Hey look, it's my code!",


### PR DESCRIPTION
the JSON currently in the repository still use chat.openai.com and twitter.com, even though they have been now set up to redirect to chatgpt.com and x.com, that is all ig